### PR TITLE
Bump split.io version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,42 +10,28 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    base64 (0.2.0)
     binding_ninja (0.2.3)
-    bitarray (1.3.0)
+    bitarray (1.3.1)
     byebug (11.1.3)
     coderay (1.1.3)
-    concurrent-ruby (1.1.10)
-    connection_pool (2.2.5)
+    concurrent-ruby (1.2.3)
+    connection_pool (2.4.1)
     diff-lcs (1.5.0)
-    faraday (1.10.0)
-      faraday-em_http (~> 1.0)
-      faraday-em_synchrony (~> 1.0)
-      faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0)
-      faraday-multipart (~> 1.0)
-      faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.0)
-      faraday-patron (~> 1.0)
-      faraday-rack (~> 1.0)
-      faraday-retry (~> 1.0)
+    faraday (2.8.1)
+      base64
+      faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
-    faraday-em_http (1.0.0)
-    faraday-em_synchrony (1.0.0)
-    faraday-excon (1.1.0)
-    faraday-httpclient (1.0.1)
-    faraday-multipart (1.0.3)
-      multipart-post (>= 1.2, < 3)
-    faraday-net_http (1.0.1)
-    faraday-net_http_persistent (1.2.0)
-    faraday-patron (1.0.0)
-    faraday-rack (1.0.0)
-    faraday-retry (1.0.3)
+    faraday-net_http (3.0.2)
+    faraday-net_http_persistent (2.1.0)
+      faraday (~> 2.5)
+      net-http-persistent (~> 4.0)
     hitimes (1.3.1)
-    json (2.6.2)
-    jwt (2.3.0)
+    json (2.7.2)
+    jwt (2.8.1)
+      base64
     lru_redux (1.1.0)
-    multipart-post (2.1.1)
-    net-http-persistent (4.0.1)
+    net-http-persistent (4.0.2)
       connection_pool (~> 2.2)
     parallel (1.22.1)
     parser (3.1.1.0)
@@ -55,7 +41,10 @@ GEM
       parser
       unparser
     rainbow (3.1.1)
-    redis (4.6.0)
+    redis (5.1.0)
+      redis-client (>= 0.17.0)
+    redis-client (0.21.1)
+      connection_pool
     regexp_parser (2.1.1)
     rexml (3.2.5)
     rspec (3.11.0)
@@ -100,19 +89,21 @@ GEM
     sorbet (0.5.10051)
       sorbet-static (= 0.5.10051)
     sorbet-runtime (0.5.10042)
+    sorbet-static (0.5.10051-universal-darwin-20)
     sorbet-static (0.5.10051-universal-darwin-21)
     sorbet-static (0.5.10051-x86_64-linux)
     sorbet-struct-comparable (1.3.0)
       sorbet-runtime (>= 0.5)
-    splitclient-rb (8.0.0)
+    splitclient-rb (8.3.1)
       bitarray (~> 1.3)
       concurrent-ruby (~> 1.0)
-      faraday (>= 1.1, < 2.0)
+      faraday (>= 1.1, < 3.0)
+      faraday-net_http_persistent (>= 1.0, < 3.0)
       json (>= 1.8, < 3.0)
       jwt (>= 1.0.0, < 3.0)
       lru_redux (~> 1.1)
       net-http-persistent (>= 2.9, < 5.0)
-      redis (>= 4.0.0, < 5.0)
+      redis (>= 4.0.0, < 6.0)
       socketry (>= 0.4, < 1.0)
       thread_safe (~> 0.3)
     thread_safe (0.3.6)
@@ -122,6 +113,7 @@ GEM
       parser (>= 3.0.0)
 
 PLATFORMS
+  arm64-darwin-20
   arm64-darwin-21
   x86_64-linux
 
@@ -136,4 +128,4 @@ DEPENDENCIES
   sorbet
 
 BUNDLED WITH
-   2.3.13
+   2.3.14


### PR DESCRIPTION
Split.io is taking too long to make the changes reflected on our end, so I ended up contacting their support and updating the split.io version was the solution they asked me to try:

<img width="934" alt="Screenshot 2024-04-05 at 14 50 08" src="https://github.com/ScreenLoop/feature-flag-rb/assets/3399488/895d234a-7c4b-466c-8ef4-fc069a48aba5">

